### PR TITLE
Remove dummy data

### DIFF
--- a/Plantify_Test/Plantify/main.py
+++ b/Plantify_Test/Plantify/main.py
@@ -29,19 +29,7 @@ def create_table_if_not_exists():
             )
         """)
         
-        # Beispieldaten hinzufügen, falls die Tabelle leer ist
-        cursor.execute("SELECT COUNT(*) FROM pflanzen")
-        count = cursor.fetchone()[0]
-        
-        if count == 0:
-            sample_plants = [
-                ("Rose",),
-                ("Tulpe",),
-                ("Sonnenblume",),
-                ("Lavendel",),
-                ("Basilikum",)
-            ]
-            cursor.executemany("INSERT INTO pflanzen (name) VALUES (?)", sample_plants)
+        # Tabelle anlegen, falls sie noch nicht existiert
         
         conn.commit()
         cursor.close()
@@ -56,22 +44,12 @@ def create_table_if_not_exists():
 def get_all_plants():
     # Zunächst versuchen, die Tabelle zu erstellen
     if not create_table_if_not_exists():
-        # Fallback: Statische Liste zurückgeben, wenn DB nicht verfügbar
-        print("Datenbank nicht verfügbar. Verwende Fallback-Daten.")
-        return [
-            {'id': 1, 'name': 'Rose'},
-            {'id': 2, 'name': 'Tulpe'},
-            {'id': 3, 'name': 'Sonnenblume'}
-        ]
+        print("Datenbank nicht verfügbar.")
+        return []
     
     conn = get_connection()
     if conn is None:
-        # Fallback falls Verbindung fehlschlägt
-        return [
-            {'id': 1, 'name': 'Rose'},
-            {'id': 2, 'name': 'Tulpe'},
-            {'id': 3, 'name': 'Sonnenblume'}
-        ]
+        return []
     
     try:
         cursor = conn.cursor()
@@ -84,12 +62,7 @@ def get_all_plants():
         print(f"Fehler beim Abrufen der Pflanzen: {e}")
         if conn:
             conn.close()
-        # Fallback bei SQL-Fehlern
-        return [
-            {'id': 1, 'name': 'Rose'},
-            {'id': 2, 'name': 'Tulpe'},
-            {'id': 3, 'name': 'Sonnenblume'}
-        ]
+        return []
 
 if __name__ == '__main__':
     plants = get_all_plants()

--- a/Plantify_Test/static/sidebar.js
+++ b/Plantify_Test/static/sidebar.js
@@ -2,15 +2,6 @@ document.addEventListener('DOMContentLoaded', function () {
     fetch('/api/items')
         .then(response => response.json())
         .then(data => {
-            // Sortierung wie auf Screenshot 2
-            const sortOrder = [
-                "monstera", "strelitzie", "orchidee", "tomate", "orchidee 2", "monstera 2"
-            ];
-            data.sort((a, b) => {
-                const aIdx = sortOrder.indexOf(a.name.toLowerCase());
-                const bIdx = sortOrder.indexOf(b.name.toLowerCase());
-                return (aIdx === -1 ? 99 : aIdx) - (bIdx === -1 ? 99 : bIdx);
-            });
 
             const list = document.getElementById('sidebar-list');
             list.innerHTML = '';


### PR DESCRIPTION
## Summary
- drop sidebar sort logic in JS
- query plant names from DB rather than using dummy sidebar items
- return actual database data in views instead of dummy results
- remove fallback and sample data from main

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c17fb6ec4832f9aabd8b295ed6f17